### PR TITLE
Expose device FILE_NAME and VERSION on home page and add OTA update link

### DIFF
--- a/PMD_fromKrake/PMD_BPM_wMQTT/ID.h
+++ b/PMD_fromKrake/PMD_BPM_wMQTT/ID.h
@@ -1,6 +1,7 @@
 
 #include <Arduino.h>
 
+#define FILE_NAME "PMD_BPM_MQTT"
 #define PROG_NAME "PMD_BPM_wMQTT "
 #define VERSION " V.0.1.10 " /// Increment version
 //#define MODEL_NAME "Model: BUTTOM"

--- a/PMD_fromKrake/PMD_BPM_wMQTT/WiFiManagerOTA.cpp
+++ b/PMD_fromKrake/PMD_BPM_wMQTT/WiFiManagerOTA.cpp
@@ -73,6 +73,14 @@ void initWiFi() {
 }
 
 String processor(const String& var) {
+    if (var == "FILE_NAME") {
+        return String(FILE_NAME);
+    }
+
+    if (var == "VERSION") {
+        return String(VERSION);
+    }
+
     if (var == "STATE") {
         if (digitalRead(WiFiLed)) {
             ledState = "ON";

--- a/PMD_fromKrake/PMD_BPM_wMQTT/data/index.html
+++ b/PMD_fromKrake/PMD_BPM_wMQTT/data/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>ESP IoT Dashboard</title>
+    <title>%FILE_NAME% %VERSION%</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="style.css">
     <link rel="icon" type="image/png" href="favicon.png">
@@ -10,10 +10,18 @@
 </head>
 <body>
     <div class="topnav">
-        <h1>KRAKE KRAKE ALL THE WAY</h1>
+        <h1>%FILE_NAME%</h1>
+        <p class="version">Version: %VERSION%</p>
     </div>
 
     <div class="content">
+        <section class="device-card">
+            <h2>Device Information</h2>
+            <p><strong>Device:</strong> %FILE_NAME%</p>
+            <p><strong>Version:</strong> %VERSION%</p>
+            <p><a class="update-link" href="/update">Open OTA update page</a></p>
+        </section>
+
         <div class="card-grid" id="led-container"></div>
     </div>
 

--- a/PMD_fromKrake/PMD_BPM_wMQTT/data/style.css
+++ b/PMD_fromKrake/PMD_BPM_wMQTT/data/style.css
@@ -5,6 +5,12 @@ html {
 h1 {
   font-size: 1.8rem;
   color: white;
+  margin-bottom: 0.25rem;
+}
+.version {
+  color: #FEFCFB;
+  font-weight: bold;
+  margin-top: 0;
 }
 .topnav {
   overflow: hidden;
@@ -15,6 +21,29 @@ body {
 }
 .content { 
   padding: 50px;
+}
+.device-card {
+  max-width: 800px;
+  margin: 0 auto 2rem;
+  padding: 1rem;
+  background-color: #FEFCFB;
+  box-shadow: 2px 2px 12px 1px rgba(140,140,140,.5);
+}
+.device-card h2 {
+  color: #034078;
+  margin-top: 0;
+}
+.update-link {
+  display: inline-block;
+  background-color: #034078;
+  border-radius: 4px;
+  color: #FEFCFB;
+  font-weight: bold;
+  padding: 0.75rem 1rem;
+  text-decoration: none;
+}
+.update-link:hover {
+  background-color: #1282A2;
 }
 .card-grid {
   max-width: 800px;


### PR DESCRIPTION
### Motivation
- Implement feature #2 from the README to serve a web page that identifies the device by name and version and provides a link to the OTA update page.

### Description
- Add `FILE_NAME` metadata to `ID.h` so the device identity can be referenced in templates.
- Extend the AsyncWebServer template `processor` in `WiFiManagerOTA.cpp` to return `FILE_NAME` and `VERSION` for template substitution.
- Replace the home page (`data/index.html`) content with `%FILE_NAME%`/`%VERSION%` placeholders, display device information, and add a link to the OTA update page at `/update`.
- Update `data/style.css` to style the version label, device information card, and the update link.

### Testing
- Ran a Python assertion script that verified the new `FILE_NAME` define, template variables in `WiFiManagerOTA.cpp`, and `%FILE_NAME%`/`%VERSION%`/`/update` presence in `data/index.html`, and all assertions passed.
- Ran `git diff --check` to ensure no whitespace or diff issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0851df36808328aadcb7ecec419ab6)