### PR TITLE
PMD_BPM_wMQTT: Add OLED Wi‑Fi status splash and button trigger

### DIFF
--- a/PMD_fromKrake/PMD_BPM_wMQTT/Button.cpp
+++ b/PMD_fromKrake/PMD_BPM_wMQTT/Button.cpp
@@ -109,6 +109,11 @@ void muteFiveMin(byte btnStatus) {
 
 void SendEmergMessage(byte btnStatus) {
   handleButtonEvent("SW4", btnStatus);
+  if (btnStatus == onPress) {
+    requestWiFiSplash();
+    return;
+  }
+
   messageToPublish = "a5Send Emergency";
   syntheticBPM = 125;  //A high BPM
 }

--- a/PMD_fromKrake/PMD_BPM_wMQTT/Button.h
+++ b/PMD_fromKrake/PMD_BPM_wMQTT/Button.h
@@ -27,6 +27,7 @@ extern DailyStruggleButton BOOT;
 
 // FLE extern ElegantOTA ;
 extern bool clearOTA;
+void requestWiFiSplash();
 
 void splashserial();
 void buttonEvent(byte btnStatus);

--- a/PMD_fromKrake/PMD_BPM_wMQTT/PMD_BPM_wMQTT.ino
+++ b/PMD_fromKrake/PMD_BPM_wMQTT/PMD_BPM_wMQTT.ino
@@ -32,6 +32,9 @@ AsyncWebServer server(80);
 AsyncWebSocket ws("/ws");
 
 bool clearOTA = false;
+bool showWiFiSplash = false;
+unsigned long wifiSplashUntil = 0;
+
 
 
 #define SCREEN_WIDTH 128
@@ -143,6 +146,76 @@ void splashOLED_P1() {
 }
 
 
+String wifiModeName() {
+  wifi_mode_t mode = WiFi.getMode();
+
+  if (mode == WIFI_AP) {
+    return "Soft AP";
+  }
+  if (mode == WIFI_AP_STA) {
+    return "AP+STA";
+  }
+  if (mode == WIFI_STA) {
+    return "STA";
+  }
+  return "OFF";
+}
+
+String wifiAddress() {
+  wifi_mode_t mode = WiFi.getMode();
+
+  if (mode == WIFI_AP || mode == WIFI_AP_STA) {
+    return WiFi.softAPIP().toString();
+  }
+  return WiFi.localIP().toString();
+}
+
+String wifiMacAddress() {
+  wifi_mode_t mode = WiFi.getMode();
+
+  if (mode == WIFI_AP || mode == WIFI_AP_STA) {
+    return WiFi.softAPmacAddress();
+  }
+  return WiFi.macAddress();
+}
+
+void displayWiFiStatusSplash(const char* status) {
+  display.clearDisplay();
+  display.setTextSize(1);
+  display.setTextColor(WHITE);
+  int row = 0;
+  const int rowHeight = 10;
+
+  display.setCursor(0, row);
+  display.println("WiFi init");
+  row += rowHeight;
+  display.setCursor(0, row);
+  display.println(status);
+  row += rowHeight;
+  display.setCursor(0, row);
+  display.println("Type: " + wifiModeName());
+  row += rowHeight;
+  display.setCursor(0, row);
+  display.println("MAC:");
+  row += rowHeight;
+  display.setCursor(0, row);
+  display.println(wifiMacAddress());
+  row += rowHeight;
+  display.setCursor(0, row);
+  display.println("IP: " + wifiAddress());
+  display.display();
+}
+
+void showWiFiStatusSplash(unsigned long durationMs) {
+  displayWiFiStatusSplash(WiFi.status() == WL_CONNECTED ? "Connected" : "Config Portal");
+  showWiFiSplash = true;
+  wifiSplashUntil = millis() + durationMs;
+}
+
+void requestWiFiSplash() {
+  showWiFiStatusSplash(5000);
+}
+
 void splashOLED() {
   display.clearDisplay();
   display.setTextSize(1);
@@ -215,9 +288,13 @@ void setup() {
   // display.setCursor(0, rowPosition);
   // display.display();
 
-  WiFiMan();
-  initWiFi();
+  displayWiFiStatusSplash("Starting");
   initLittleFS();
+  displayWiFiStatusSplash("WiFiManager");
+  WiFiMan();
+  displayWiFiStatusSplash("Connecting");
+  initWiFi();
+  showWiFiStatusSplash(5000);
   setupOTA();
   server.begin();             // Start web page server
   ElegantOTA.begin(&server);  // Start ElegantOTA
@@ -249,7 +326,6 @@ void setup() {
 
   setupButton();  //Buttons, switches
   pulse.begin();
-  splashOLED();
 
   // More setup code here
   digitalWrite(LED_1, LOW);        //Make built in LED low at end of setup.
@@ -325,7 +401,15 @@ void loop() {
 
   }  // end MQTT publishing
 
-  updateOLED();
+  if (showWiFiSplash) {
+    if (millis() >= wifiSplashUntil) {
+      showWiFiSplash = false;
+    }
+  }
+
+  if (!showWiFiSplash) {
+    updateOLED();
+  }
 
   //Check of clearOTA.
   if (true == clearOTA) {

--- a/PMD_fromKrake/PMD_BPM_wMQTT/WiFiManagerOTA.cpp
+++ b/PMD_fromKrake/PMD_BPM_wMQTT/WiFiManagerOTA.cpp
@@ -6,6 +6,7 @@ const char* default_ssid = DEVICE_UNDER_TEST;  // Default AP Name
 String ssid = "";
 String password = "";
 String ledState = "";
+extern void displayWiFiStatusSplash(const char* status);
 // const int WiFiLed = 2;  // Modify based on actual LED pin
 
 void saveCredentials(const char* ssid, const char* password) {
@@ -39,6 +40,9 @@ bool loadCredentials() {
 
 void WiFiMan() {
     WiFiManager wifiManager;
+    wifiManager.setAPCallback([](WiFiManager*) {
+        displayWiFiStatusSplash("Config Portal");
+    });
 
     if (!loadCredentials()) {
         if (!wifiManager.autoConnect(default_ssid)) {


### PR DESCRIPTION
### Motivation
- Implement the README third feature to have the OLED report Wi‑Fi initialization status (type, MAC, IP) and allow re‑displaying that splash temporarily. 
- Make Wi‑Fi initialization and config portal state visible on the device without blocking the main BPM display loop. 

### Description
- Add helper functions `wifiModeName()`, `wifiAddress()`, `wifiMacAddress()`, `displayWiFiStatusSplash()`, `showWiFiStatusSplash()` and `requestWiFiSplash()` to render a Wi‑Fi status splash on the OLED for a timed interval. 
- Update `setup()` to mount `LittleFS` earlier and show stepwise Wi‑Fi initialization progress then call `showWiFiStatusSplash(5000)` to keep the splash visible for five seconds. 
- Add a non‑blocking `showWiFiSplash` state and update `loop()` to suppress the regular BPM OLED while the Wi‑Fi splash is showing. 
- Wire WiFiManager AP callback to call `displayWiFiStatusSplash("Config Portal")` so the OLED reflects entering the config portal, and add `requestWiFiSplash()` to `Button.h` and call it on SW4 short‑press in `Button.cpp` to re‑display the Wi‑Fi splash. 
- Modified files: `PMD_fromKrake/PMD_BPM_wMQTT/PMD_BPM_wMQTT.ino`, `PMD_fromKrake/PMD_BPM_wMQTT/WiFiManagerOTA.cpp`, `PMD_fromKrake/PMD_BPM_wMQTT/Button.cpp`, and `PMD_fromKrake/PMD_BPM_wMQTT/Button.h`.

### Testing
- Ran `git diff --check` to validate the working tree (no whitespace errors) which succeeded. 
- Attempted `arduino-cli compile --fqbn esp32:esp32:esp32 PMD_fromKrake/PMD_BPM_wMQTT` but the tool is not available in this environment so the compilation step was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08587ec3508328b867a17f8a7a7448)