### PR TITLE
Display stored Wi‑Fi credentials on OLED and Serial during boot (PMD_BPM_wMQTT v0.1.11)

### DIFF
--- a/PMD_fromKrake/PMD_BPM_wMQTT/ID.h
+++ b/PMD_fromKrake/PMD_BPM_wMQTT/ID.h
@@ -3,7 +3,7 @@
 
 #define FILE_NAME "PMD_BPM_MQTT"
 #define PROG_NAME "PMD_BPM_wMQTT "
-#define VERSION " V.0.1.10 " /// Increment version
+#define VERSION " V.0.1.11 " /// Increment version
 //#define MODEL_NAME "Model: BUTTOM"
 #define MODEL_NAME "Model: HW2_WiFiReady_Elegant"
 #define DEVICE_UNDER_TEST "SN: 00001"

--- a/PMD_fromKrake/PMD_BPM_wMQTT/PMD_BPM_wMQTT.ino
+++ b/PMD_fromKrake/PMD_BPM_wMQTT/PMD_BPM_wMQTT.ino
@@ -212,6 +212,35 @@ void showWiFiStatusSplash(unsigned long durationMs) {
   wifiSplashUntil = millis() + durationMs;
 }
 
+void displayWiFiCredentialsSplash(const String& networkSsid, const String& networkPassword) {
+  display.clearDisplay();
+  display.setTextSize(1);
+  display.setTextColor(WHITE);
+
+  int row = 0;
+  const int rowHeight = 10;
+
+  display.setCursor(0, row);
+  display.println("WiFi credentials");
+  row += rowHeight;
+  display.setCursor(0, row);
+  display.println("SSID:");
+  row += rowHeight;
+  display.setCursor(0, row);
+  display.println(networkSsid.substring(0, 21));
+  row += rowHeight;
+  display.setCursor(0, row);
+  display.println("Password:");
+  row += rowHeight;
+  display.setCursor(0, row);
+  display.println(networkPassword.substring(0, 21));
+  row += rowHeight;
+  display.setCursor(0, row);
+  display.println("Serial has full text");
+  display.display();
+  delay(5000);
+}
+
 void requestWiFiSplash() {
   showWiFiStatusSplash(5000);
 }

--- a/PMD_fromKrake/PMD_BPM_wMQTT/README.md
+++ b/PMD_fromKrake/PMD_BPM_wMQTT/README.md
@@ -1,21 +1,21 @@
 ## Summary
-An ESP32 project.  
-Based on an ESP32 Dev Kit1  
-As of about Jun 15 2025, Device connects to a WiFi network with WiFi Manager and device accept OTA update with Eligant OTA.  
+An ESP32 project.
+Based on an ESP32 Dev Kit1
+As of about Jun 15 2025, Device connects to a WiFi network with WiFi Manager and device accept OTA update with Eligant OTA.
 
 ## Future features
 Incrementally add the following features.
 
 1. Increment the version
 2. Serve a web page which identifies the device as FILE_NAME (PMD_BPM_MQTT) and version number. The home web page will have a link to the update page.
-3. The OLED display will report the status of the Wi-Fi initialization. It will show the Wi-Fi type such as soft AP or STA. It will report the device MAC address. 
+3. The OLED display will report the status of the Wi-Fi initialization. It will show the Wi-Fi type such as soft AP or STA. It will report the device MAC address.
 It will report the IP address of the Soft AP or the STA.  This splash screen will stay visible for five seconds. After which the progream resumes as per its current behavior. There is a active low button on GPIO35. Pressing it for a time greater than a debounce time and less than 1 second will cause the splash screen to again display, again for 5 seconds.
-4. During boot, after the stage reporting "Loaded WiFi credentials from storage." Display on OLED and print to Serial Monitor the credentials so that a user could know and trouble shoot WiFi connection problems.
+4. [x] During boot, after the stage reporting "Loaded WiFi credentials from storage." Display on OLED and print to Serial Monitor the credentials so that a user could know and trouble shoot WiFi connection problems.
 5. Change the default MQTT broker from "public.cloud.shiftr.io" to "krakepubinv.cloud.shiftr.io". Make so can choose one or other using an ifdef where the compile defin is "PUBLIC_BROKER" for "public.cloud.shiftr.io". So if not "PUBLIC_BROKER" then "krakepubinv.cloud.shiftr.io". Increment the version.
 6. TBD...
 
 
-## Boot message as of V.0.1.10
+## Boot message as of V.0.1.11
 ```
 ets Jul 29 2019 12:21:46
 
@@ -30,15 +30,18 @@ load:0x40080400,len:3600
 entry 0x400805f0
 E (345) ADC: adc1_lock_release(419): adc1 lock release called before acquire
 ===================================
-PMD_BPM_wMQTT  V.0.1.10 
+PMD_BPM_wMQTT  V.0.1.11
 Model: HW2_WiFiReady_Elegant
 SN: 00001
 Compiled at: May 16 2026 07:31:32
-GNU Affero General Public License, version 3 
+GNU Affero General Public License, version 3
 ===================================
 
 LittleFS mounted successfully.
 Loaded WiFi credentials from storage.
+WiFi credentials loaded from LittleFS:
+  SSID: <stored-ssid>
+  Password: <stored-password>
 Connected to WiFi!
 Connecting to WiFi ....
 

--- a/PMD_fromKrake/PMD_BPM_wMQTT/WiFiManagerOTA.cpp
+++ b/PMD_fromKrake/PMD_BPM_wMQTT/WiFiManagerOTA.cpp
@@ -7,6 +7,7 @@ String ssid = "";
 String password = "";
 String ledState = "";
 extern void displayWiFiStatusSplash(const char* status);
+extern void displayWiFiCredentialsSplash(const String& networkSsid, const String& networkPassword);
 // const int WiFiLed = 2;  // Modify based on actual LED pin
 
 void saveCredentials(const char* ssid, const char* password) {
@@ -35,6 +36,10 @@ bool loadCredentials() {
     
     file.close();
     Serial.println("Loaded WiFi credentials from storage.");
+    Serial.println("WiFi credentials loaded from LittleFS:");
+    Serial.println("  SSID: " + ssid);
+    Serial.println("  Password: " + password);
+    displayWiFiCredentialsSplash(ssid, password);
     return true;
 }
 


### PR DESCRIPTION
### Motivation
- Complete the README's fourth future feature by surfacing stored Wi‑Fi credentials at boot to aid troubleshooting. 
- Provide a human‑readable OLED splash plus full details on the Serial console so users can verify what LittleFS returned.

### Description
- Added `displayWiFiCredentialsSplash(const String&, const String&)` to `PMD_fromKrake/PMD_BPM_wMQTT/PMD_BPM_wMQTT.ino` to render SSID and password on the OLED for five seconds. 
- Modified `PMD_fromKrake/PMD_BPM_wMQTT/WiFiManagerOTA.cpp` to print the loaded SSID and password to Serial and call the OLED splash after `loadCredentials()` succeeds.
- Declared the new OLED splash function as `extern` where needed and bumped the firmware `VERSION` in `PMD_fromKrake/PMD_BPM_wMQTT/ID.h` to `V.0.1.11`.
- Updated `PMD_fromKrake/PMD_BPM_wMQTT/README.md` to mark feature 4 as done and to show the revised boot message example.

### Testing
- Ran `git diff --check` to validate whitespace/trailing issues and it reported no blocking problems. 
- Executed a Python check that verified presence of feature markers (`WiFi credentials loaded from LittleFS`, `displayWiFiCredentialsSplash`, and `V.0.1.11`) and it passed. 
- Attempted an Arduino build (`arduino-cli`/`platformio`) but no build tool is available in the environment so compilation could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0994eb2c6c8328a583f88ee9bde13b)